### PR TITLE
Fix Docker socket group detection in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,8 +15,12 @@ usermod -u "${USER_ID}" -o node
 # Grant access to the host's Docker socket if it's mounted.
 if [ -S /var/run/docker.sock ]; then
   DOCKER_GID=$(stat -c '%g' /var/run/docker.sock)
-  getent group "${DOCKER_GID}" &>/dev/null || groupadd -g "${DOCKER_GID}" -o docker
-  usermod -aG docker node
+  DOCKER_GROUP_NAME=$(getent group "${DOCKER_GID}" | cut -d: -f1 || true)
+  if [ -z "${DOCKER_GROUP_NAME}" ]; then
+    DOCKER_GROUP_NAME=docker
+    groupadd -g "${DOCKER_GID}" -o "${DOCKER_GROUP_NAME}"
+  fi
+  usermod -aG "${DOCKER_GROUP_NAME}" node
 fi
 
 # --- Bootstrap Settings ---


### PR DESCRIPTION
## Summary
- handle Docker sockets whose group has a non-standard name
- avoid failing when `docker` group name is absent

## Testing
- `bash -n entrypoint.sh`
- `bash -n claude-yolo`
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689529b554e0832f8d032d8c68b87e1b